### PR TITLE
Overrode redcap_module_link_check_display() to reproduce previous lin…

### DIFF
--- a/TableauConnector.php
+++ b/TableauConnector.php
@@ -20,7 +20,12 @@ use ExternalModules\AbstractExternalModule;
  * REDCap External Module: Tableau Connector
  */
 class TableauConnector extends AbstractExternalModule
-{        
+{
+        public function redcap_module_link_check_display()
+        {
+                return true;
+        }
+
         /**
          * Print the page of instructions 
          */


### PR DESCRIPTION
…k display behavior.  We discussed this briefly in the following issue:

https://github.com/lsgs/redcap-tableau-wdc/issues/1

There's a chance this change will be included in the next REDCap release on Friday, so this should likely be merged and a new module version submitted as soon as possible. If for any reason you'd like me to display the roll out of this change, just let me know.