### PR TITLE
Add exportfFieldFormat, allowing users to specify whether Tableau var…

### DIFF
--- a/config.json
+++ b/config.json
@@ -86,6 +86,14 @@
 			"default": "Raw data or labels?"
 		},
 		{
+			"key": "connector-page-fieldformat-label",
+			"name": "Connector page export field format field label",
+			"required": true,
+			"allow-project-overrides": false,
+			"type": "text",
+			"default": "Variable name or field label?"
+		},
+		{
 			"key": "connector-page-dag-label",
 			"name": "Connector page include DAG field label",
 			"required": true,


### PR DESCRIPTION
…iables should be named after REDCap  variable names or REDCap field labels

Our local user of the Tableau Web Data Connector external module built her Tableau workbooks initially using exported data from REDCap and would like to use the same workbooks, but pulling data directly from REDCap via the WDC external  module.

To that end, I've updated the WDC external module to include an additional question about whether column names in Tableau should be named after a REDCap field's variable name or label.