### PR TITLE
Remove empty strings/nulls from data; Enable proper numbers/floats; Mark booleans as ints

### DIFF
--- a/TableauConnector.php
+++ b/TableauConnector.php
@@ -222,7 +222,12 @@ if (typeof tableau==='undefined') { alert('Error: could not download tableau con
             dataType: "json",
             success: function(resp){
                 resp.forEach(function(record){
-                    tableData.push(record);
+		    $.each(record, function(key, value) {
+			if (value === "" || value === null) {
+			  delete record[key];
+			    }
+		      });
+		     tableData.push(record);
                 });
                 table.appendRows(tableData);
                 doneCallback();
@@ -289,10 +294,6 @@ if (typeof tableau==='undefined') { alert('Error: could not download tableau con
 		    f.alias = f.description+' (choice='+getCheckboxChoiceLabel($response, rcExportVarname)+')';
 		  }
 
-                  // Set raw value of checkbox fields to an int
-                  else {
-                      dataType = 'integer';
-                  }
 		  f.description = getCheckboxChoiceLabel($response, rcExportVarname)+' | '+f.description;
                 }
 
@@ -354,11 +355,11 @@ if (typeof tableau==='undefined') { alert('Error: could not download tableau con
         switch (dtype) {
             case 'integer': return tableau.dataTypeEnum.int; break;
             case 'text': return tableau.dataTypeEnum.string; break;
-            case 'float': return tableau.dataTypeEnum.string; break;
+            case 'float': return tableau.dataTypeEnum.float; break;
             case 'date': return tableau.dataTypeEnum.date; break;
             case 'datetime': return tableau.dataTypeEnum.datetime; break;
             case 'partialDatetime': return tableau.dataTypeEnum.datetime; break;
-            case 'boolean': return tableau.dataTypeEnum.string; break;
+            case 'boolean': return tableau.dataTypeEnum.int; break;
             default: return tableau.dataTypeEnum.string;
         }
     };

--- a/wdc.php
+++ b/wdc.php
@@ -4,7 +4,6 @@
  * File wdc.php is for the Web Data Connector URL
  * @author Luke Stevens, Murdoch Children's Research Institute
  */
-use HtmlPage;
 $page = new HtmlPage();
 $page->PrintHeaderExt();
 


### PR DESCRIPTION
In previous versions of the TWDC, fields with number validation were set up in Tableau as ints and fields with decimal validation were set up in Tableau as floats, but this was changed because it caused the problem that empty string or NULL values were turned into zeros rather than being left as an empty string or a NULL. 

Based on an online comment (https://community.tableau.com/message/606568#606568), it seems that the reason these values were being altered is that when a value that doesn't fit the validation of a Tableau column is received, such as an empty string for an integer or a float column, then that value is changed to be the default. The expected way to pass in a NULL value to Tableau is actually to not include that value at all when preparing the array of values.

1) I've included a small loop that walks through all of the values for every column and removes the value entirely. This seems to work well for integer, float, and (probably) boolean columns in Tableau, but I'm not 100% sure it's the right choice for string columns.

2) I've added back in the use of integer columns for REDCap fields with number validation, and I've also added back in the use of float columns for REDCap fields with decimal validation.

3) I've set yesno, true/false, and checkbox REDCap fields -- basically anything that REDCap considers a boolean -- to use Tableau integer columns rather than boolean columns. This is particularly applicable to checkbox fields, which really can't be anything but checked or unchecked, but may not be the best choice for yesno and truefalse. My one customer here at IU was happy with it, but it's maybe not the right choice all of the time.

It's possible a pull request is premature at this time, and the questions raised above (should string columns get an empty string or a NULL?; Should yesno and truefalse use a boolean or an int column?) should be answered before moving forward. I'm submitting this pull request now simply because my one customer is happy with this, so I'm happy to move forward, but I'm certainly willing to discuss this.