### PR TITLE
Handles checkbox fields with less than expected whitespace in choices

### DIFF
--- a/TableauConnector.php
+++ b/TableauConnector.php
@@ -375,7 +375,7 @@ if (typeof tableau==='undefined') { alert('Error: could not download tableau con
         var choiceOptionString = $response.find( 'CodeList[OID="'+rcExportVarname+'.choices"]' ).attr('redcap:CheckboxChoices');
         var choiceVarVal = rcExportVarname.split('___');
         var choiceLabel = choiceVarVal;
-        choiceOptionString.split(' | ').forEach(function(c) {
+        choiceOptionString.split(/\s*\|\s*/g).forEach(function(c) {
             if (c.lastIndexOf(choiceVarVal[1]+', ', 0)===0) { // if (c.startsWith(choiceVarVal[1]+', ')) { // do not use startsWith() !
                 choiceLabel = c.replace(choiceVarVal[1]+', ', '');
             }


### PR DESCRIPTION
We ran into a problem where checkbox fields are occasionally missing expected whitespace, as in:

1, choice1| 2, choice2 | 3, choice3

Notice how there's no whitespace between 'choice1' and the following pipe character. Adding a regexpression allows there to be differeing amounts of whitespace.